### PR TITLE
Usa una variabile senza dati non ancora renderizzati

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -70,7 +70,7 @@
   <meta name="twitter:site" content="@{{ site.author.twitter }}" />
   <meta name="twitter:creator" content="@{{ site.author.twitter }}" />
   <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
-  <meta name="twitter:description" content="{{ page.content | strip_html | xml_escape | truncatewords: 50 }}" />
+  <meta name="twitter:description" content="{{ page.excerpt | strip_html | xml_escape | truncatewords: 50 }}" />
   {% if page.share-img %}
   <meta name="twitter:image" content="{{ page.share-img }}" />
   {% elsif site.avatar %}


### PR DESCRIPTION
Usa `post.excerpt` invece di `post.content` in quanto quest'ultimo può contenere codice Markdown non ancora renderizzato.

Vedi [issue](https://github.com/jekyll/jekyll-archives/issues/28).

fixes #27
