### PR TITLE
Il link telegram nel footer ora punta al canale 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ author:
   instagram: terremotocentro # eg. daattali
   youtube: yourlink # eg. user/daattali or channel/daattali
   rss: https://emergenzehack.github.io/terremotocentro/feed.xml
-  telegram: https://telegram.me/joinchat/BgW6eEBsI3rLKsJk9L7FJg
+  telegram: https://telegram.me/terremotocentroitalia
 
 # Select which links to show in the footer
 footer-links-active:


### PR DESCRIPTION
Questo per rendere il canale (il nostro _"prodotto"_) più visibile. Il link al gruppo resta comunque nella pagina "About".
