### PR TITLE
Resize og_image

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -67,6 +67,8 @@
   <meta property="og:image" content="{{ page.share-img }}" />
   {% elsif site.avatar %}
   <meta property="og:image" content="{{ site.url }}{{ site.avatar }}" />
+  <meta property="og:image:width" content="310" />
+  <meta property="og:image:height" content="310" />
   {% else %}
   <meta property="og:image" content="" />
   {% endif %}


### PR DESCRIPTION
Modificata la dimensione dell'avatar in og_image in accordo con le [linee guida di Facebook](https://developers.facebook.com/docs/sharing/best-practices) in maniera tale da modificare il post condiviso su Facebook.

Vecchio post:
![old](https://cloud.githubusercontent.com/assets/16691846/18102934/cd9e02fa-6ef4-11e6-8a5f-9bc26b084db4.png)

Nuovo post:
![new](https://cloud.githubusercontent.com/assets/16691846/18102939/cfa09f72-6ef4-11e6-8d15-e36bca5bc480.png)
