### PR TITLE
Evitare redirect 301 e Fix navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,22 +22,22 @@ description: Un progetto per informare sul terremoto del 24 Agosto 2016
 # List of links in the navigation bar
 navbar-links:
   Aggiornamenti:
-    - Bollettino: "bollettino"
-    - Blog: "post"
+    - Bollettino: "bollettino/"
+    - Blog: "post/"
   Hai bisogno?:
-    - Segnala: "aiuto"
-    - Alloggi: "alloggi"
-    - Vittime: "vittime"
-    - Link utili: "link_utili"
-  Mappe: "mappe"
-  Vuoi donare?: "donare"
-    - Donazioni: "donazioni" 
-    - Raccolta Fondi: "raccolte_fondi"
-    - Fabbisogni: "fabbisogni"
+    - Segnala: "aiuto/"
+    - Alloggi: "alloggi/"
+    - Vittime: "vittime/"
+    - Link utili: "link_utili/"
+  Mappe: "mappe/"
+  Vuoi donare?:
+    - Donazioni: "donazioni/" 
+    - Raccolta Fondi: "raccolte_fondi/"
+    - Fabbisogni: "fabbisogni/"
   Il Progetto:
-   - About: "about"
+   - About: "about/"
    - WIKI: 'https://github.com/emergenzeHack/terremotocentro/wiki" target="_blank'
-   - Press: "press"
+   - Press: "press/"
 
 # Image to show in the navigation bar - image must be a square (width = height)
 # Remove this parameter if you don't want an image in the navbar


### PR DESCRIPTION
Nel menù i link alle varie sezioni rimandano alla sezione senza slash, che poi fa un redirect verso quella con lo slash.

![link](https://cloud.githubusercontent.com/assets/16691846/18123925/6244832c-6f70-11e6-9eb9-04664b805316.png)

Aggiunti gli slash direttamente nel menù per evitare il redirect.

Corretto anche il menù per far funzionare la #156 
