### PR TITLE
Aggiunto supporto a travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _site
 Gemfile.lock
 node_modules
 package.json
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+rvm:
+  - 2.1
+
+cache: bundler
+
+script: ./scripts/cibuild
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'html-proofer'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # [TerremotoCentroItalia.info](http://terremotocentroitalia.info/)
 
+[![Build Status](https://travis-ci.org/emergenzeHack/terremotocentro.svg)](https://travis-ci.org/emergenzeHack/terremotocentro)
+
 Sito creato per informazioni sul Terremoto del Centro Italia del 2016-08-24.
 
 Tutte le informazioni su come contribuire nella [nostra wiki](https://github.com/emergenzeHack/terremotocentro/wiki).

--- a/_config.yml
+++ b/_config.yml
@@ -191,5 +191,7 @@ gems:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
 
+exclude: [vendor]
+
 # Beautiful Jekyll / Dean Attali
 # 2fc73a3a967e97599c9763d05e564189

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+bundle exec jekyll build
+bundle exec htmlproofer --disable-external ./_site


### PR DESCRIPTION
Uno con i permessi di "amministratore" del repository deve comunque aggiungere il repository a Travis https://travis-ci.org/profile/ (se vi serve una mano fatemi un fischio, sono @tredaelli su Telegram) e poi si può mergiare sto commit.

Attualmente alcuni test falliscono in quanto ci sono diversi problemi sia sullo spreadsheet (alcuni già risolti da me grazie al report di jekyll che potete, per ora, trovare qui https://travis-ci.org/drizzt/terremotocentro/) sia su legal.md.
