### PR TITLE
Fix ancore duplicate

### DIFF
--- a/donazioni.md
+++ b/donazioni.md
@@ -6,7 +6,7 @@ permalink: /donazioni/
 
 {% for member in site.data.donazioni %}
 
-{% assign memberId = member.Cosa|slugify|truncate:20,"" %}
+{% assign memberId = member.Cosa|slugify|truncate:30,"" %}
 {% capture memberUrl %}{{site.url}}{{page.url}}#{{memberId}}{% endcapture %}
 {% capture memberName %}{{member.Cosa}}{% endcapture %}
 


### PR DESCRIPTION
Fix delle ancore duplicate a causa del fatto che la descrizione "Cosa" comincia spesso nello stesso modo ossia con "Materiali di prima necessità".
Aumentando la lunghezza dell'ID il problema si risolve.
