### PR TITLE
Aggiunta pagina di ricerca (issue #8)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ navbar-links:
    - WIKI: 'https://github.com/emergenzeHack/terremotocentro/wiki" target="_blank'
    - Press: "press/"
    - Canali di Comunicazione: "canali/"
+  Cerca: "search/"
 
 # Image to show in the navigation bar - image must be a square (width = height)
 # Remove this parameter if you don't want an image in the navbar

--- a/css/search.css
+++ b/css/search.css
@@ -1,0 +1,41 @@
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/search.md
+++ b/search.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Cerca
+permalink: /search/
+css: "/css/search.css"
+---
+<div id="google-custom-search">
+    
+<script>
+  (function() {
+    var cx = '014020732301088317916:amxa0vslvf8';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search></gcse:search>
+    
+    
+</div>

--- a/search.md
+++ b/search.md
@@ -21,3 +21,6 @@ css: "/css/search.css"
     
     
 </div>
+<div id="filler" style="min-height:600px;">
+&nbsp;
+</div>


### PR DESCRIPTION
Ho creato una pagina dedicata alla ricerca, dove all'utente viene presentata una casella del google custom search engine (http://cse.google.com). 
Il foglio di stile dedicato css/search.css è necessario in quanto la casella di ricerca è estremamente complessa e ancora adesso non è molto bella da vedere, ma funziona. Si potrebbe aprire un singolo issue per abbellire la casella di ricerca.
